### PR TITLE
added SSE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project is meant to provide tools to use s3 as a storage solution for Alfre
 
 ## Installation
 
- * This module does not work stand alone out of the box but will require further configuration. Either install it as an amp in your alfresco installation and configure it using spring xml files in shared/classes/extension/s3-override-context.xml.
+ * This module does not work stand alone out of the box but will require further configuration. Either install it as an amp in your alfresco installation and configure it using spring xml files in shared/classes/alfresco/extension/s3-override-context.xml.
  * If you have your own amp project you can include the s3 module as a dependency.
  
 ### Use as content store selector

--- a/alfresco-s3-adapter-platform/src/main/java/org/redpill/alfresco/s3/S3ContentStore.java
+++ b/alfresco-s3-adapter-platform/src/main/java/org/redpill/alfresco/s3/S3ContentStore.java
@@ -59,6 +59,7 @@ public class S3ContentStore extends AbstractContentStore
   private String rootDirectory;
   private String endpoint;
   private String signatureVersion;
+  private String sseAlgorithm;
   private int connectionTimeout = 50000;
   private int maxErrorRetry = 5;
   private long connectionTTL = 60000L;
@@ -219,6 +220,10 @@ public class S3ContentStore extends AbstractContentStore
     this.accessKey = accessKey;
   }
   
+  public void setSseAlgorithm(String sseAlgorithm) {
+	    this.sseAlgorithm = sseAlgorithm;
+	  }
+  
   public void setSecretKey(String secretKey) {
     this.secretKey = secretKey;
   }
@@ -265,7 +270,7 @@ public class S3ContentStore extends AbstractContentStore
     
     String key = makeS3Key(contentUrl);
     
-    return new S3ContentWriter(bucketName, key, contentUrl, existingContentReader, s3Client, transferManager);
+    return new S3ContentWriter(bucketName, key, contentUrl, existingContentReader, s3Client, transferManager, sseAlgorithm);
     
   }
 

--- a/alfresco-s3-adapter-platform/src/main/java/org/redpill/alfresco/s3/S3ContentWriter.java
+++ b/alfresco-s3-adapter-platform/src/main/java/org/redpill/alfresco/s3/S3ContentWriter.java
@@ -1,7 +1,11 @@
 package org.redpill.alfresco.s3;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.transfer.TransferManager;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+
 import org.alfresco.repo.content.AbstractContentWriter;
 import org.alfresco.service.cmr.repository.ContentIOException;
 import org.alfresco.service.cmr.repository.ContentReader;
@@ -10,11 +14,8 @@ import org.alfresco.util.TempFileProvider;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.OutputStream;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.transfer.TransferManager;
 
 /**
  * S3 content writer
@@ -31,13 +32,15 @@ public class S3ContentWriter extends AbstractContentWriter {
   private final String bucketName;
   private File tempFile;
   private long size;
+  private String sseAlgorithm;
 
-  public S3ContentWriter(String bucketName, String key, String contentUrl, ContentReader existingContentReader, AmazonS3 client, TransferManager transferManager) {
+  public S3ContentWriter(String bucketName, String key, String contentUrl, ContentReader existingContentReader, AmazonS3 client, TransferManager transferManager, String sseAlgorithm) {
     super(contentUrl, existingContentReader);
     this.key = key;
     this.client = client;
     this.transferManager = transferManager;
     this.bucketName = bucketName;
+    this.sseAlgorithm = sseAlgorithm;
     addListener(new S3WriteStreamListener(this));
   }
 
@@ -87,5 +90,12 @@ public class S3ContentWriter extends AbstractContentWriter {
 
   public File getTempFile() {
     return tempFile;
+  }
+  
+  public String getSSEAlgorithm() {
+	  if (sseAlgorithm != null && !sseAlgorithm.trim().isEmpty())
+		  return sseAlgorithm;
+	  else
+		  return null;
   }
 }

--- a/alfresco-s3-adapter-platform/src/main/resources/alfresco/module/alfresco-s3-adapter-platform/alfresco-global.properties
+++ b/alfresco-s3-adapter-platform/src/main/resources/alfresco/module/alfresco-s3-adapter-platform/alfresco-global.properties
@@ -11,6 +11,9 @@ aws.regionName=us-east-1
 # The S3 bucket name to use as the content store
 aws.s3.bucketName=
 
+# Which SSE (server side encryption) algorithm to use (default is none)
+aws.s3.sse=
+
 # The endpoint url if other than AWS (for other S3-compatible vendors)
 aws.s3.endpoint=
 

--- a/alfresco-s3-adapter-platform/src/main/resources/alfresco/module/alfresco-s3-adapter-platform/context/s3-context.xml
+++ b/alfresco-s3-adapter-platform/src/main/resources/alfresco/module/alfresco-s3-adapter-platform/context/s3-context.xml
@@ -85,6 +85,7 @@
     <property name="accessKey" value="${aws.accessKey}"/>
     <property name="secretKey" value="${aws.secretKey}"/>
     <property name="bucketName" value="${aws.s3.bucketName}"/>
+    <property name="sseAlgorithm" value="${aws.s3.sse}"/>
     <property name="regionName" value="${aws.regionName}"/>
     <property name="rootDirectory" value="${aws.s3.rootDirectory}"/>
     <property name="endpoint" value="${aws.s3.endpoint}"/>


### PR DESCRIPTION
I've added support for server-side encryption (SSE). One can specify a SSE algorithm in the alfresco-global.properties by adding the property "aws.s3.sse" with the value either being nothing for no SSE (default), "AES256" for "Server-Side Encryption with Amazon S3-Managed Keys (SSE-S3, AES-256)" or "aws:kms" for "Server-Side Encryption with AWS KMS-Managed Keys (SSE-KMS)".